### PR TITLE
switch from "x/net/context" to "context"

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,13 +1,12 @@
 package socks5
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package socks5
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"github.com/hanwen/go-fuse/splice"
@@ -198,6 +199,9 @@ func (s *Server) handleConnect(ctx context.Context, conn conn, req *Request) err
 	if err := sendReply(conn, successReply, &bind); err != nil {
 		return fmt.Errorf("Failed to send reply: %v", err)
 	}
+
+	bufConn, _ := req.bufConn.(*bufio.Reader)
+	bufConn.Discard(bufConn.Buffered())
 
 	// Start proxying
 	errCh := make(chan error, 2)

--- a/request.go
+++ b/request.go
@@ -368,8 +368,11 @@ func proxy(dst io.Writer, src io.Reader, errCh chan error) {
 	TcpDst := dst.(*net.TCPConn)
 	TcpSrc := src.(*net.TCPConn)
 
-	TcpSrc.SetReadBuffer(16 * 1024)
-	TcpDst.SetWriteBuffer(16 * 1024)
+	TcpSrc.SetReadBuffer(256 * 1024)
+	TcpSrc.SetWriteBuffer(256 * 1024)
+
+	TcpDst.SetReadBuffer(256 * 1024)
+	TcpDst.SetWriteBuffer(256 * 1024)
 
 	FdDst, _ := TcpDst.File()
 	FdSrc, _ := TcpSrc.File()

--- a/request.go
+++ b/request.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hanwen/go-fuse/splice"
 	"io"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 )

--- a/request.go
+++ b/request.go
@@ -359,12 +359,15 @@ type closeWriter interface {
 func proxy(dst io.Writer, src io.Reader, errCh chan error) {
 	pair, err := splice.Get()
 
-	pdst := dst.(*os.File)
-	psrc := src.(*os.File)
+	TcpDst := dst.(*net.TCPConn)
+	TcpSrc := src.(*net.TCPConn)
+
+	FdDst, _ := TcpDst.File()
+	FdSrc, _ := TcpSrc.File()
 
 	if err == nil {
 		for {
-			w, err := splice.SpliceCopy(pdst, psrc, pair)
+			w, err := splice.SpliceCopy(FdDst, FdSrc, pair)
 			if err != nil || w == 0 {
 				break
 			}

--- a/request.go
+++ b/request.go
@@ -368,6 +368,9 @@ func proxy(dst io.Writer, src io.Reader, errCh chan error) {
 	TcpDst := dst.(*net.TCPConn)
 	TcpSrc := src.(*net.TCPConn)
 
+	TcpSrc.SetReadBuffer(16 * 1024)
+	TcpDst.SetWriteBuffer(16 * 1024)
+
 	FdDst, _ := TcpDst.File()
 	FdSrc, _ := TcpSrc.File()
 

--- a/request.go
+++ b/request.go
@@ -363,6 +363,7 @@ type closeWriter interface {
 // down a dedicated channel
 func proxy(dst io.Writer, src io.Reader, errCh chan error) {
 	pair, err := splice.Get()
+	pair.MaxGrow()
 
 	TcpDst := dst.(*net.TCPConn)
 	TcpSrc := src.(*net.TCPConn)

--- a/resolver.go
+++ b/resolver.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"net"
-
-	"golang.org/x/net/context"
 )
 
 // NameResolver is used to implement custom name resolution

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDNSResolver(t *testing.T) {

--- a/ruleset.go
+++ b/ruleset.go
@@ -1,7 +1,7 @@
 package socks5
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // RuleSet is used to provide custom rules to allow or prohibit actions

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -1,9 +1,8 @@
 package socks5
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestPermitCommand(t *testing.T) {

--- a/socks5.go
+++ b/socks5.go
@@ -2,12 +2,11 @@ package socks5
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/socks5.go
+++ b/socks5.go
@@ -143,7 +143,7 @@ func (s *Server) ServeConn(conn net.Conn) error {
 		return err
 	}
 
-	request, err := NewRequest(bufConn)
+	request, err := NewRequest(bufConn, conn)
 	if err != nil {
 		if err == unrecognizedAddrType {
 			if err := sendReply(conn, addrTypeNotSupported, nil); err != nil {


### PR DESCRIPTION
 Go 1.7 moves the golang.org/x/net/context package into the standard library as context